### PR TITLE
Support emitting the end of tag name when newline and tab are used

### DIFF
--- a/js/react/jsxLoader.js
+++ b/js/react/jsxLoader.js
@@ -666,7 +666,7 @@
                         }
                     } else if (nextChar === '>') {
                         break;
-                    } else if (nextChar === ' ') {
+                    } else if (nextChar === ' ' || nextChar === '\n' || nextChar === '\t') {
                         foundName = true;
                         continue;
                     } else if (nextChar === ')' || nextChar === '&' || nextChar === '|' || nextChar === '?' || nextChar === ';') {

--- a/test/js/unit-testing-react.js
+++ b/test/js/unit-testing-react.js
@@ -648,6 +648,24 @@ describe('jsxLoader.js', function() {
             expect(js).to.equal('"use strict";\nReact.createElement(Test, {message: "test", value: 123}, "Hello")');
         });
 
+        it('should compile nested element with newline', function() {
+            resetIfUsingPreact();
+            var jsx = '<Test message="test" value={123}><div\ntitle="test">Hello</div></Test>';
+            var js = jsxLoader.compiler.compile(jsx);
+            console.log(js);
+            console.log(JSON.stringify(js));
+            expect(js).to.equal('"use strict";\nReact.createElement(Test, {message: "test", value: 123}, \n            React.createElement("div", {title: "test"}, "Hello"))');
+        });
+
+        it('should compile nested element with tab', function() {
+            resetIfUsingPreact();
+            var jsx = '<Test message="test" value={123}><div\ttitle="test">Hello</div></Test>';
+            var js = jsxLoader.compiler.compile(jsx);
+            console.log(js);
+            console.log(JSON.stringify(js));
+            expect(js).to.equal('"use strict";\nReact.createElement(Test, {message: "test", value: 123}, \n            React.createElement("div", {title: "test"}, "Hello"))');
+        });
+
         it('should have correct child whitespace nodes', function() {
             resetIfUsingPreact();
             var jsx = '<div><strong className={this.props.cssClass}>Test:</strong> {this.props.name} <section>Test [{this.props.name}] <span className="test">Test2</span></section></div>';


### PR DESCRIPTION
I encountered an issue with jsxLoader where valid JSX elements with a valid tag name were skipped during compilation. I found that this only happened with nested elements, and only when followed by a newline or tab white space character. These are valid terminators for the tag name, and can easily be added by hand or by prettification of JSX code.

This pull request adds tests and support for these cases.

Tests have been ran locally and confirm both before and after the change to jsxLoader.

BEFORE:
<img width="878" height="343" alt="image" src="https://github.com/user-attachments/assets/8a1c958e-7170-4875-8b9a-a96fcd375b5d" />

AFTER:
<img width="705" height="186" alt="image" src="https://github.com/user-attachments/assets/4233abdc-c394-4558-bd91-763e49a022df" />
